### PR TITLE
Fix Glob return value for empty result

### DIFF
--- a/glob.go
+++ b/glob.go
@@ -33,7 +33,7 @@ func Glob(ctx context.Context, pattern string) ([]string, error) {
 	}()
 	defer cancel()
 
-	var ret []string
+	ret := make([]string, 0)
 	for {
 		match, err := gr.Next()
 		if err != nil {


### PR DESCRIPTION
Better return an empty slice instead of nil, to ensure we have the same result
as filepath.Glob.