### PR TITLE
Make Next() return immediately when the Stream is closed.

### DIFF
--- a/glob.go
+++ b/glob.go
@@ -92,7 +92,6 @@ func (g *Result) Next() (string, error) {
 	case r := <-g.results:
 		return r, nil
 	case <-g.done:
-		g.Close()
 		return "", nil
 	}
 }

--- a/glob.go
+++ b/glob.go
@@ -51,6 +51,7 @@ func Glob(ctx context.Context, pattern string) ([]string, error) {
 type Result struct {
 	errors  chan error
 	results chan string
+	done    <-chan struct{}
 	cancel  context.CancelFunc
 }
 
@@ -63,6 +64,7 @@ func Stream(pattern string) Result {
 	g := Result{
 		errors:  make(chan error),
 		results: make(chan string),
+		done:    ctx.Done(),
 		cancel:  cancel,
 	}
 	go func() {
@@ -89,6 +91,9 @@ func (g *Result) Next() (string, error) {
 		return "", err
 	case r := <-g.results:
 		return r, nil
+	case <-g.done:
+		g.Close()
+		return "", nil
 	}
 }
 


### PR DESCRIPTION
Large directories can cause the [`Readdirnames`](https://pkg.go.dev/os#File.Readdirnames) function to block for quite some time, causing the internal `stream` function, and consequently the `Next` function, to also block. This is not desirable and can be fixed by making `Next` consider the `Done()` channel of the context that this Stream is tied to.

In general I'm not a fan of this "maintain a ton of channels" style, but in this case it seems like the best solution without rewriting the whole thing. That's because while the `stream` function doesn't return, we can't close the exiting channels yet, because they might still be written to.