### PR TITLE
Add `NextWithContext` function

### DIFF
--- a/glob.go
+++ b/glob.go
@@ -77,12 +77,17 @@ func Stream(pattern string) Result {
 
 // Next returns the next match from the pattern. It returns an empty string when
 // the matches are exhausted.
+//
+// Next might block while reading directory entries in the background.
 func (g *Result) Next() (string, error) {
 	return g.NextWithContext(context.Background())
 }
 
 // NextWithContext returns the next match from the pattern. It returns an empty
-// string when the matches are exhausted, or the given context was canceled.
+// string when the matches are exhausted.
+//
+// NextWithContext might block while reading directory entries in the
+// background, but respects context cancelation.
 func (g *Result) NextWithContext(ctx context.Context) (string, error) {
 	// Note: Next never returns filepath.ErrBadPattern if it has previously
 	// returned a match. This isn't specified but it's highly desirable in

--- a/glob.go
+++ b/glob.go
@@ -78,6 +78,12 @@ func Stream(pattern string) Result {
 // Next returns the next match from the pattern. It returns an empty string when
 // the matches are exhausted.
 func (g *Result) Next() (string, error) {
+	return g.NextWithContext(context.Background())
+}
+
+// NextWithContext returns the next match from the pattern. It returns an empty
+// string when the matches are exhausted, or the given context was canceled.
+func (g *Result) NextWithContext(ctx context.Context) (string, error) {
 	// Note: Next never returns filepath.ErrBadPattern if it has previously
 	// returned a match. This isn't specified but it's highly desirable in
 	// terms of least-surprise. I don't think there's a concise way for this
@@ -89,6 +95,8 @@ func (g *Result) Next() (string, error) {
 		return "", err
 	case r := <-g.results:
 		return r, nil
+	case <-ctx.Done():
+		return "", ctx.Err()
 	}
 }
 


### PR DESCRIPTION
Large directories can cause the [Readdirnames](https://pkg.go.dev/os#File.Readdirnames) function to block for quite some time, causing the internal stream function, and consequently the Next function, to also block.

For cases where blocking function calls are not desirable, we add a `NextWithContext` function that does the same but respects context cancelation.

The name of this function is up for debate.