### PR TITLE
Fix deadlock when calling `Close`

### DIFF
--- a/glob.go
+++ b/glob.go
@@ -125,7 +125,10 @@ func stream(pattern string, results chan<- string, cancel <-chan struct{}) error
 		if _, err := os.Lstat(pattern); err != nil {
 			return nil
 		}
-		results <- pattern
+		select {
+		case results <- pattern:
+		case <-cancel:
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Not all attempts to write to the `result` channel respected context cancelation of the stream's goroutine. This was probably never noticed because a call to `Next` blocked until `results` (or `errors`) was read from.

This is not necessarily the case with the new `NextWithContext` function, resulting in a deadlock in the following way:
- `stream` attempts to write to `results`, but has no readers
- If now `Close` gets called, it waits for messages from `errors`, which never happens because the `stream` function can't return

We fix this by making sure that all channel writes respect context cancelation. And with that, we can also get rid of the "cleanup" part in `Close` where the channels are drained.